### PR TITLE
Update for Python 3.9+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,6 @@ _wormtable_module = Extension('_wormtable',
     sources = ["_wormtablemodule.c", "halffloat.c"],
     libraries = ["db"])
 
-requirements = []
-v = sys.version_info[:2]
-if v < (2, 7) or v == (3, 0) or v == (3, 1):
-    requirements.append("argparse")
-
 setup(
     name = "wormtable",
     version = wormtable_version,
@@ -47,13 +42,10 @@ setup(
     classifiers = [
         "Programming Language :: C",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.1",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Environment :: Other Environment",
         "Intended Audience :: Science/Research",
@@ -62,7 +54,6 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
-    requires = requirements,
     long_description = wormtable_readme,
     ext_modules = [_wormtable_module],
     packages = ['wormtable'],

--- a/wormtable/__init__.py
+++ b/wormtable/__init__.py
@@ -17,7 +17,7 @@
 # along with wormtable.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 from .tables import *  # NOQA
 from .vcf2wt import vcf2wt_main

--- a/wormtable/tables.py
+++ b/wormtable/tables.py
@@ -747,7 +747,7 @@ class Table(Database):
         Parses the schema xml and updates the state of this table.
         """
         xml_columns = schema.find("columns")
-        for xmlcol in xml_columns.getchildren():
+        for xmlcol in xml_columns:
             col = Column.parse_xml(xmlcol)
             self.__column_name_map[col.get_name()]= len(self.__columns)
             self.__columns.append(col)
@@ -756,7 +756,7 @@ class Table(Database):
         """
         Parses the specified XML to retrieve the statistics for this table.
         """
-        for stat in stats.getchildren():
+        for stat in stats:
             name = stat.get("name")
             value = stat.get("value")
             # TODO this really isn't very good at all.
@@ -1054,7 +1054,7 @@ class Index(Database):
         if version not in supported_versions:
             raise ValueError("Unsupported index metadata version - rebuild required.")
         xml_key_columns = root.find("key_columns")
-        for xmlcol in xml_key_columns.getchildren():
+        for xmlcol in xml_key_columns:
             if xmlcol.tag != "key_column":
                 raise ValueError("invalid xml")
             name = xmlcol.get("name")
@@ -1209,7 +1209,7 @@ class Index(Database):
         return ret
 
 
-class IndexCounter(collections.Mapping):
+class IndexCounter(collections.abc.Mapping):
     """
     A counter for Indexes, based on the collections.Counter class. This class
     is a dictionary-like object that represents a mapping of the distinct


### PR DESCRIPTION
Fix a few minor issues from deprecated and removed methods and classes.

Remove Python 2.7 support 